### PR TITLE
Cleanup EstimateCodeSize magic numbers

### DIFF
--- a/runtime/compiler/optimizer/EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corp. and others
+ * Copyright (c) 2000, 2021 IBM Corp. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -56,7 +56,7 @@ TR_EstimateCodeSize::get(TR_InlinerBase * inliner, TR_InlinerTracer *tracer, int
 
    estimator->_sizeThreshold = sizeThreshold;
    estimator->_realSize = 0;
-   estimator->_error = 0;
+   estimator->_error = ECS_NORMAL;
 
    estimator->_numOfEstimatedCalls = 0;
    estimator->_hasNonColdCalls = true;
@@ -149,12 +149,12 @@ TR_EstimateCodeSize::isInlineable(TR_CallStack * prevCallStack, TR_CallSite *cal
    }
 
 bool
-TR_EstimateCodeSize::returnCleanup(int32_t anerrno)
+TR_EstimateCodeSize::returnCleanup(EcsCleanupErrorStates errorState)
    {
-   _error = anerrno;
+   _error = errorState;
    if (_mayHaveVirtualCallProfileInfo)
       _inliner->comp()->decInlineDepth(true);
-   if (anerrno > 0)
+   if (errorState > 0)
       return false;
    else
       return true;

--- a/runtime/compiler/optimizer/EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.hpp
@@ -36,6 +36,16 @@ struct TR_CallTarget;
 
 #define MAX_ECS_RECURSION_DEPTH 30
 
+enum EcsCleanupErrorStates {
+   ECS_NORMAL = 0,
+   ECS_RECURSION_DEPTH_THRESHOLD_EXCEEDED,
+   ECS_OPTIMISTIC_SIZE_THRESHOLD_EXCEEDED,
+   ECS_VISITED_COUNT_THRESHOLD_EXCEEDED,
+   ECS_REAL_SIZE_THRESHOLD_EXCEEDED,
+   ECS_ARGUMENTS_INCOMPATIBLE,
+   ECS_CALLSITES_CREATION_FAILED
+};
+
 class TR_EstimateCodeSize
    {
    public:
@@ -78,7 +88,7 @@ class TR_EstimateCodeSize
 
    int32_t getSize()                   { return _realSize; }
    virtual int32_t getOptimisticSize() { return 0; } // override in subclasses that support partial inlining
-   int32_t getError()                  { return _error; }
+   EcsCleanupErrorStates getError()    { return _error; }
    int32_t getSizeThreshold()          { return _sizeThreshold; }
    bool aggressivelyInlineThrows()     { return _aggressivelyInlineThrows; }
    bool recursedTooDeep()              { return _recursedTooDeep; }
@@ -103,10 +113,10 @@ class TR_EstimateCodeSize
    /*
     *  \brief common tasks requiring completion before returning from estimation
     *
-    *  \param errorNumber
-    *       an unique number used to identify where estimate code size bailed out
+    *  \param errorState
+    *       an unique state used to identify where estimate code size bailed out
     */
-   bool returnCleanup(int32_t errorNumber );
+   bool returnCleanup(EcsCleanupErrorStates errorState);
 
    /* Fields */
 
@@ -122,7 +132,7 @@ class TR_EstimateCodeSize
 
    int32_t _sizeThreshold;
    int32_t _realSize;        // size once we know if we're doing a partial inline or not
-   int32_t _error;
+   EcsCleanupErrorStates _error;
 
    int32_t _totalBCSize;     // Pure accumulation of the bytecode size. Used by HW-based inlining.
 

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1104,14 +1104,14 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
    if( comp()->getVisitCount() > HIGH_VISIT_COUNT )
       {
       heuristicTrace(tracer(),"Depth %d: estimateCodeSize aborting due to high comp()->getVisitCount() of %d",_recursionDepth,comp()->getVisitCount());
-      return returnCleanup(3);
+      return returnCleanup(ECS_VISITED_COUNT_THRESHOLD_EXCEEDED);
       }
 
    if (_recursionDepth > MAX_ECS_RECURSION_DEPTH)
       {
       calltarget->_isPartialInliningCandidate = false;
       heuristicTrace(tracer(), "*** Depth %d: ECS end for target %p signature %s. Exceeded Recursion Depth", _recursionDepth, calltarget, callerName);
-      return returnCleanup(1);
+      return returnCleanup(ECS_RECURSION_DEPTH_THRESHOLD_EXCEEDED);
       }
 
    InterpreterEmulator bci(calltarget, methodSymbol, static_cast<TR_J9VMBase *> (comp()->fej9()), comp(), tracer(), this);
@@ -1136,7 +1136,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
    if (!TR_PrexArgInfo::validateAndPropagateArgsFromCalleeSymbol(argsFromSymbol, calltarget->_ecsPrexArgInfo, tracer()))
    {
       heuristicTrace(tracer(), "*** Depth %d: ECS end for target %p signature %s. Incompatible arguments", _recursionDepth, calltarget, callerName);
-      return returnCleanup(6);
+      return returnCleanup(ECS_ARGUMENTS_INCOMPATIBLE);
    }
 
    NeedsPeekingHeuristic nph(calltarget, bci, methodSymbol, comp());
@@ -1301,7 +1301,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
       if (!bci.findAndCreateCallsitesFromBytecodes(wasPeekingSuccessfull, iteratorWithState))
          {
          heuristicTrace(tracer(), "*** Depth %d: ECS end for target %p signature %s. bci.findAndCreateCallsitesFromBytecode failed", _recursionDepth, calltarget, callerName);
-         return returnCleanup(7);
+         return returnCleanup(ECS_CALLSITES_CREATION_FAILED);
          }
       _hasNonColdCalls = bci._nonColdCallExists;
       }
@@ -1408,13 +1408,13 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
       {
       calltarget->_isPartialInliningCandidate = false;
       heuristicTrace(tracer(), "*** Depth %d: ECS end for target %p signature %s. optimisticSize exceeds Size Threshold", _recursionDepth, calltarget, callerName);
-      return returnCleanup(2);
+      return returnCleanup(ECS_OPTIMISTIC_SIZE_THRESHOLD_EXCEEDED);
       }
 
    if (!recurseDown)
       {
       heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. recurseDown set to false. size = %d _fullSize = %d", _recursionDepth, calltarget, callerName, size, calltarget->_fullSize);
-      return returnCleanup(0);
+      return returnCleanup(ECS_NORMAL);
       }
 
    /****************** Phase 4: Deal with Inlineable Calls **************************/
@@ -1427,7 +1427,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
       if (_realSize > sizeThreshold)
          {
          heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. real size %d exceeds sizeThreshold %d", _recursionDepth,calltarget, callerName,_realSize,sizeThreshold);
-         return returnCleanup(4);
+         return returnCleanup(ECS_REAL_SIZE_THRESHOLD_EXCEEDED);
          }
 
       if (blocks[i])
@@ -1609,7 +1609,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                   if(comp()->getVisitCount() > HIGH_VISIT_COUNT)
                      {
                      heuristicTrace(tracer(),"Depth %d: estimateCodeSize aborting due to high comp()->getVisitCount() of %d",_recursionDepth,comp()->getVisitCount());
-                     return returnCleanup(3);
+                     return returnCleanup(ECS_VISITED_COUNT_THRESHOLD_EXCEEDED);
                      }
                   }
                else if (calltargetSetTooBig)
@@ -1630,7 +1630,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                   if(comp()->getVisitCount() > HIGH_VISIT_COUNT)
                      {
                      heuristicTrace(tracer(),"Depth %d: estimateCodeSize aborting due to high comp()->getVisitCount() of %d",_recursionDepth,comp()->getVisitCount());
-                     return returnCleanup(3);
+                     return returnCleanup(ECS_VISITED_COUNT_THRESHOLD_EXCEEDED);
                      }
                   }
 
@@ -1699,10 +1699,10 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
    if (_realSize > sizeThreshold)
       {
       heuristicTrace(tracer(),"*** Depth %d: ECS end for target %p signature %s. real size exceeds Size Threshold", _recursionDepth,calltarget, callerName);
-      return returnCleanup(4);
+      return returnCleanup(ECS_REAL_SIZE_THRESHOLD_EXCEEDED);
       }
 
-   return returnCleanup(0);
+   return returnCleanup(ECS_NORMAL);
    }
 
 bool TR_J9EstimateCodeSize::reduceDAAWrapperCodeSize(TR_CallTarget* target)


### PR DESCRIPTION
Replace `anerrno` magic numbers with `EcsCleanupErrorStates`
enum values to identify the error location during code
size estimation.

Closes: #8664
Signed-off-by: Amarpreet Singh amarpreet1997@gmail.com